### PR TITLE
Allow custom defaults types

### DIFF
--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -527,7 +527,7 @@ class Column(Selectable):
         elif (
             default is None
             and None in allowed_types
-            or type(default) in allowed_types
+            or isinstance(default, tuple(allowed_types))
         ):
             self._validated = True
             return True
@@ -540,7 +540,7 @@ class Column(Selectable):
                 self._validated = True
                 return True
         elif (
-            isinstance(default, Enum) and type(default.value) in allowed_types
+            isinstance(default, Enum) and isinstance(default.value, tuple(allowed_types))
         ):
             self._validated = True
             return True


### PR DESCRIPTION
These changes allow for extension of existing Default types, for instance, introducing UUID7 would now be possible just like this:
```python
from uuid import UUID

from piccolo import columns
from piccolo.columns.defaults import UUID4
from piccolo.table import Table
from uuid_utils.compat import uuid7


class UUID7(UUID4):
    @property
    def postgres(self) -> str:
        return "uuid_generate_v7()"

    def python(self) -> UUID:
        return uuid7()


class User(Table, tablename="users"):
    id = columns.UUID(primary_key=True, default=UUID7())

